### PR TITLE
Add modular app structure with blueprints and config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+uploads/
+generated/

--- a/app.py
+++ b/app.py
@@ -1,34 +1,21 @@
-from flask import Flask, render_template, request, Response
-import xml.etree.ElementTree as ET
+from flask import Flask
+from xlights_seq.config import Config
+from xlights_seq import main_bp
+import os
 
-app = Flask(__name__)
 
-@app.route('/', methods=['GET', 'POST'])
-def index():
-    if request.method == 'POST':
-        model_name = request.form.get('model_name', 'Model1')
-        duration = int(request.form.get('duration', 30)) * 1000  # Convert seconds to ms
-        effect_type = request.form.get('effect_type', 'On')
+def create_app(config_class=Config):
+    app = Flask(__name__, template_folder='templates', static_folder='static')
+    app.config.from_object(config_class)
 
-        # Generate basic xLights sequence XML dynamically
-        root = ET.Element('xrgb', version='2024.05', showDir='.')
-        
-        timing_grids = ET.SubElement(root, 'timingGrids')
-        timing_grid = ET.SubElement(timing_grids, 'timingGrid', saveID='0', type='FREQ', name='New Timing', lengthMS=str(duration), spacing='50', visibility='1')
-        
-        display_elements = ET.SubElement(root, 'displayElements')
-        display_element = ET.SubElement(display_elements, 'displayElement', name=model_name, type='model', visibility='1')
-        
-        effects = ET.SubElement(root, 'effects')
-        effect_layer = ET.SubElement(effects, 'effectLayer', timing='0')
-        effect_settings = f"E_CHECKBOX_{effect_type}_RampUp=0,E_SLIDER_{effect_type}_RampUp=0,E_CHECKBOX_{effect_type}_RampDown=0,E_SLIDER_{effect_type}_RampDown=0,E_CHECKBOX_{effect_type}_Background=0"
-        effect = ET.SubElement(effect_layer, 'effect', ref='0', type=effect_type, startTime='0', endTime=str(duration), intensity='100', palette='C_BUTTON_Palette1=#FFFFFF,C_BUTTON_Palette2=#000000', settings=effect_settings)
-        
-        xml_content = ET.tostring(root, encoding='unicode', method='xml')
-        
-        return Response(xml_content, mimetype='text/xml', headers={"Content-Disposition": "attachment; filename=generated_sequence.xml"})
-    
-    return render_template('index.html')
+    # Ensure directories exist
+    for folder in (app.config['UPLOAD_FOLDER'], app.config['OUTPUT_FOLDER']):
+        os.makedirs(folder, exist_ok=True)
+
+    app.register_blueprint(main_bp)
+    return app
+
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    app = create_app()
+    app.run(host='0.0.0.0', port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask==3.0.3
-# For future audio analysis, uncomment: librosa==0.10.2.post1
-# For XML parsing (built-in, no need to install)
+librosa==0.10.2.post1
+soundfile==0.12.1
+numpy==1.26.4

--- a/static/main.js
+++ b/static/main.js
@@ -1,0 +1,6 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('upload-form');
+  form.addEventListener('submit', (e) => {
+    // Placeholder for client-side handling
+  });
+});

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,39 +1,22 @@
 <!doctype html>
 <html lang="en">
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>xLights Sequence Generator</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <meta charset="utf-8">
+  <title>xLights Sequence Generator</title>
 </head>
-<body class="container mt-5">
-    <h1 class="mb-4">xLights Sequence Generator</h1>
-    <p>Use the form below to generate a basic sequence XML file. This is expandable for future features like audio uploads and model views.</p>
-    <form method="post" class="mb-3">
-        <div class="mb-3">
-            <label for="model_name" class="form-label">Model Name</label>
-            <input type="text" class="form-control" id="model_name" name="model_name" value="Model1" required>
-        </div>
-        <div class="mb-3">
-            <label for="duration" class="form-label">Duration (seconds)</label>
-            <input type="number" class="form-control" id="duration" name="duration" value="30" min="1" required>
-        </div>
-        <div class="mb-3">
-            <label for="effect_type" class="form-label">Effect Type</label>
-            <select class="form-select" id="effect_type" name="effect_type">
-                <option value="On">On</option>
-                <option value="Off">Off</option>
-                <option value="Ramp">Ramp</option>
-            </select>
-        </div>
-        <button type="submit" class="btn btn-primary">Generate Sequence</button>
-    </form>
-    <!-- Placeholder for future expansions, e.g., tabs or modals -->
-    <div id="future-features" class="card mt-4">
-        <div class="card-body">
-            <h5>Coming Soon: Audio Upload, Model Viewer, etc.</h5>
-        </div>
+<body>
+  <h1>xLights Sequence Generator</h1>
+  <form id="upload-form" action="/generate" method="post" enctype="multipart/form-data">
+    <div>
+      <label for="xml">Sequence XML</label>
+      <input type="file" name="xml" id="xml" accept=".xml">
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <div>
+      <label for="audio">Audio File</label>
+      <input type="file" name="audio" id="audio" accept=".mp3,.wav,.m4a,.aac">
+    </div>
+    <button type="submit">Generate</button>
+  </form>
+  <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>

--- a/xlights_seq/__init__.py
+++ b/xlights_seq/__init__.py
@@ -1,0 +1,26 @@
+import os
+from werkzeug.utils import secure_filename
+from flask import Blueprint, render_template, request, jsonify, current_app
+from .utils import allowed_file
+
+main_bp = Blueprint('main', __name__)
+
+@main_bp.get('/')
+def index():
+    return render_template('index.html')
+
+@main_bp.post('/generate')
+def generate():
+    uploads = current_app.config['UPLOAD_FOLDER']
+    saved = {}
+    xml = request.files.get('xml')
+    if xml and allowed_file(xml.filename, current_app.config['ALLOWED_XML']):
+        filename = secure_filename(xml.filename)
+        xml.save(os.path.join(uploads, filename))
+        saved['xml'] = filename
+    audio = request.files.get('audio')
+    if audio and allowed_file(audio.filename, current_app.config['ALLOWED_AUDIO']):
+        filename = secure_filename(audio.filename)
+        audio.save(os.path.join(uploads, filename))
+        saved['audio'] = filename
+    return jsonify(saved)

--- a/xlights_seq/audio.py
+++ b/xlights_seq/audio.py
@@ -1,0 +1,1 @@
+"""Audio processing module placeholder."""

--- a/xlights_seq/config.py
+++ b/xlights_seq/config.py
@@ -1,0 +1,9 @@
+import os
+
+class Config:
+    SECRET_KEY = os.environ.get("SECRET_KEY","devkey")
+    MAX_CONTENT_LENGTH = 100 * 1024 * 1024  # 100MB
+    UPLOAD_FOLDER = os.path.abspath("uploads")
+    OUTPUT_FOLDER = os.path.abspath("generated")
+    ALLOWED_XML = {"xml"}
+    ALLOWED_AUDIO = {"mp3","wav","m4a","aac"}

--- a/xlights_seq/generator.py
+++ b/xlights_seq/generator.py
@@ -1,0 +1,1 @@
+"""Sequence generator module placeholder."""

--- a/xlights_seq/parsers.py
+++ b/xlights_seq/parsers.py
@@ -1,0 +1,1 @@
+"""Parsers module placeholder."""

--- a/xlights_seq/utils.py
+++ b/xlights_seq/utils.py
@@ -1,0 +1,2 @@
+def allowed_file(filename, allowed):
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in allowed


### PR DESCRIPTION
## Summary
- add `xlights_seq` package with config, utilities, and blueprint routes
- replace legacy app with an app factory that creates upload/output dirs
- simplify template and static assets for uploading XML and audio

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689767a3b0148330a01eb506e999b400