### PR TITLE
Add file upload blueprint and utilities

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -8,12 +8,31 @@
   <h1>xLights Sequence Generator</h1>
   <form id="upload-form" action="/generate" method="post" enctype="multipart/form-data">
     <div>
-      <label for="xml">Sequence XML</label>
-      <input type="file" name="xml" id="xml" accept=".xml">
+      <label for="xml">xlights_rgbeffect.xml</label>
+      <input type="file" name="xml" id="xml" accept=".xml" required>
     </div>
     <div>
-      <label for="audio">Audio File</label>
-      <input type="file" name="audio" id="audio" accept=".mp3,.wav,.m4a,.aac">
+      <label for="audio">audio.mp3</label>
+      <input type="file" name="audio" id="audio" accept=".mp3,.wav,.m4a,.aac" required>
+    </div>
+    <fieldset>
+      <legend>BPM mode</legend>
+      <label><input type="radio" name="bpm_mode" value="auto" checked> Auto</label>
+      <label><input type="radio" name="bpm_mode" value="manual"> Manual</label>
+    </fieldset>
+    <div>
+      <label for="duration">Duration override (ms)</label>
+      <input type="number" name="duration" id="duration" min="0">
+    </div>
+    <div>
+      <label for="offset">Start offset (ms)</label>
+      <input type="number" name="offset" id="offset" min="0">
+    </div>
+    <div>
+      <label for="preset">Effect preset</label>
+      <select name="preset" id="preset">
+        <option value="default">Default</option>
+      </select>
     </div>
     <button type="submit">Generate</button>
   </form>

--- a/xlights_seq/utils.py
+++ b/xlights_seq/utils.py
@@ -1,2 +1,39 @@
+import os
+from werkzeug.utils import secure_filename
+
+
 def allowed_file(filename, allowed):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in allowed
+
+
+def secure_ext(filename, allowed):
+    """Return a secure filename if its extension is allowed.
+
+    The filename is sanitized using :func:`werkzeug.utils.secure_filename` and
+    the extension is validated against the provided set of ``allowed``
+    extensions. The returned value will be ``None`` if the filename does not
+    contain an extension or if the extension is not permitted.
+    """
+
+    name = secure_filename(filename)
+    if '.' not in name:
+        return None
+    ext = name.rsplit('.', 1)[1].lower()
+    if ext not in allowed:
+        return None
+    return name
+
+
+def path_in(folder, name):
+    """Generate an absolute path for ``name`` inside ``folder``.
+
+    A ``ValueError`` is raised if the resulting path would escape the target
+    ``folder``. This helps protect against directory traversal attacks when
+    saving user supplied filenames.
+    """
+
+    base = os.path.abspath(folder)
+    path = os.path.abspath(os.path.join(base, name))
+    if not path.startswith(base + os.sep):
+        raise ValueError("invalid path")
+    return path


### PR DESCRIPTION
## Summary
- Implement upload blueprint with index and generate routes that validate files, save uploads, and respond with job info
- Add secure_ext and path_in helpers for safe filename and path handling
- Expand index template form with BPM mode, timing overrides, and effect presets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689769a06c9483309959b1df02a3e66c