### PR TITLE
Parse models from uploaded XML

### DIFF
--- a/xlights_seq/__init__.py
+++ b/xlights_seq/__init__.py
@@ -5,6 +5,7 @@ import uuid
 from flask import Blueprint, render_template, request, jsonify, current_app
 
 from .utils import secure_ext, path_in
+from .parsers import parse_models
 
 
 main_bp = Blueprint("main", __name__)
@@ -49,16 +50,17 @@ def generate():
             return jsonify(ok=False, error="file too large"), 400
 
     os.makedirs(uploads, exist_ok=True)
-    xml.save(path_in(uploads, xml_name))
+    xml_path = path_in(uploads, xml_name)
+    xml.save(xml_path)
     audio.save(path_in(uploads, audio_name))
 
+    models = [mi.__dict__ for mi in parse_models(xml_path)]
     job_id = uuid.uuid4().hex
     response = {
         "ok": True,
         "jobId": job_id,
-        "models": [],
+        "models": models,
         "durationMs": 0,
         "bpm": 0,
     }
     return jsonify(response)
-

--- a/xlights_seq/parsers.py
+++ b/xlights_seq/parsers.py
@@ -1,1 +1,38 @@
-"""Parsers module placeholder."""
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+
+
+@dataclass
+class ModelInfo:
+    name: str
+    strings: int | None = None
+    nodes: int | None = None
+
+
+def parse_models(xml_path: str) -> list[ModelInfo]:
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+    models: list[ModelInfo] = []
+
+    # xLights rgbeffects: models often under <models><model name="...">...</model></models>
+    for m in root.findall(".//model"):
+        name = m.get("name") or m.get("Model")
+        strings = m.get("StringCount") or m.get("strings")
+        nodes = m.get("Nodes") or m.get("nodes")
+        models.append(
+            ModelInfo(
+                name=name,
+                strings=int(strings) if strings else None,
+                nodes=int(nodes) if nodes else None,
+            )
+        )
+
+    # de-dup names, keep first occurrence
+    seen = set()
+    uniq: list[ModelInfo] = []
+    for mi in models:
+        if mi.name and mi.name not in seen:
+            uniq.append(mi)
+            seen.add(mi.name)
+
+    return uniq


### PR DESCRIPTION
## Summary
- implement ModelInfo dataclass and XML parser
- parse models on /generate and return them in response

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68976b23aa98833083035a6fab705160