### PR TITLE
Add section timing track based on onset strength

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,7 +48,12 @@ def generate():
         analysis = analyze_beats(audio_path)
     except Exception:
         # Safe fallback if beat detection fails
-        analysis = {"bpm": None, "duration_s": 180.0, "beat_times": [i*0.5 for i in range(int(180/0.5))]}
+        analysis = {
+            "bpm": None,
+            "duration_s": 180.0,
+            "beat_times": [i * 0.5 for i in range(int(180 / 0.5))],
+            "sections": [],
+        }
 
     duration_s = float(analysis["duration_s"])
     duration_ms = int(duration_s * 1000)
@@ -64,7 +69,9 @@ def generate():
         beat_times = analysis["beat_times"]
         bpm_val = analysis.get("bpm")
 
-    tree = build_rgbeffects(models, beat_times, duration_ms, preset)
+    sections = analysis.get("sections")
+
+    tree = build_rgbeffects(models, beat_times, duration_ms, preset, sections)
 
     job_dir = os.path.join(app.config["OUTPUT_FOLDER"], job)
     os.makedirs(job_dir, exist_ok=True)

--- a/tests/test_generator_mapping.py
+++ b/tests/test_generator_mapping.py
@@ -35,3 +35,23 @@ def test_skip_small_model_for_heavy_effect():
     names = [m.get("name") for m in root.findall("model")]
     assert "small" not in names
     assert "big" in names
+
+
+def test_sections_timing_track():
+    models = [ModelInfo(name="m1")]
+    beat_times = [0, 1, 2, 3]
+    sections = [
+        {"time": 1.0, "label": "Intro"},
+        {"time": 2.0, "label": "Verse"},
+    ]
+    tree = build_rgbeffects(models, beat_times, duration_ms=4000, preset="solid_pulse", sections=sections)
+    root = tree.getroot()
+    timing_tracks = root.findall("timing")
+    names = [t.get("name") for t in timing_tracks]
+    assert "Sections" in names
+    sec_track = [t for t in timing_tracks if t.get("name") == "Sections"][0]
+    markers = sec_track.findall("marker")
+    assert markers[0].get("label") == "Intro"
+    assert markers[0].get("timeMS") == "1000"
+    assert markers[1].get("label") == "Verse"
+    assert markers[1].get("timeMS") == "2000"

--- a/xlights_seq/audio.py
+++ b/xlights_seq/audio.py
@@ -1,8 +1,51 @@
 import librosa
+import numpy as np
+
 
 def analyze_beats(audio_path: str):
+    """Analyze an audio file for beat times and coarse section changes.
+
+    In addition to the per-beat timing returned by ``librosa.beat.beat_track``,
+    this function estimates high-level sections ("Intro", "Verse", "Chorus") by
+    grouping beats based on onset strength.  Section boundaries are marked when
+    the beat-synchronous onset strength crosses quantile thresholds.
+
+    Returns a dictionary with keys ``bpm``, ``beat_times``, ``duration_s`` and
+    ``sections`` (a list of ``{"time": float, "label": str}``).
+    """
+
     # Load mono for speed
     y, sr = librosa.load(audio_path, mono=True)
-    tempo, beat_times = librosa.beat.beat_track(y=y, sr=sr, trim=True, units="time")
+
+    # Beat tracking gives us the tempo and beat frame indices
+    tempo, beat_frames = librosa.beat.beat_track(y=y, sr=sr, trim=True)
+    beat_times = librosa.frames_to_time(beat_frames, sr=sr)
+
+    # Onset strength envelope to gauge musical intensity
+    onset_env = librosa.onset.onset_strength(y=y, sr=sr)
+    # Sample the onset envelope at beat locations
+    beat_env = onset_env[beat_frames]
+
+    sections = []
+    if len(beat_env) > 0:
+        # Quantile-based grouping into three rough energy bands
+        q1, q2 = np.quantile(beat_env, [1 / 3, 2 / 3])
+        labels = np.digitize(beat_env, [q1, q2])  # 0,1,2 -> low, mid, high
+        section_names = ["Intro", "Verse", "Chorus"]
+
+        prev_label = labels[0]
+        for i in range(1, len(labels)):
+            if labels[i] != prev_label:
+                sections.append({
+                    "time": float(beat_times[i]),
+                    "label": section_names[labels[i]],
+                })
+                prev_label = labels[i]
+
     duration = float(librosa.get_duration(y=y, sr=sr))
-    return { "bpm": float(tempo), "beat_times": beat_times.tolist(), "duration_s": duration }
+    return {
+        "bpm": float(tempo),
+        "beat_times": beat_times.tolist(),
+        "duration_s": duration,
+        "sections": sections,
+    }

--- a/xlights_seq/generator.py
+++ b/xlights_seq/generator.py
@@ -35,14 +35,39 @@ COLOR_CYCLE = [
 ]
 
 
-def build_rgbeffects(models, beat_times, duration_ms, preset: str):
-    """Generate an xLights RGB effects file using a preset."""
+def build_rgbeffects(models, beat_times, duration_ms, preset: str, sections=None):
+    """Generate an xLights RGB effects file using a preset.
+
+    Parameters
+    ----------
+    models : list
+        Sequence of ``ModelInfo`` objects describing the layout models.
+    beat_times : list[float]
+        Beat timestamps in seconds.
+    duration_ms : int
+        Total duration of the song in milliseconds.
+    preset : str
+        Name of the effect preset to apply.
+    sections : list[dict], optional
+        Optional list of section markers as returned by ``analyze_beats``.
+        Each item must contain ``time`` (seconds) and ``label``.
+    """
 
     root = ET.Element("xrgb", version="2024.05", showDir=".")
-    # timing track
+    # timing track for beats
     timing = ET.SubElement(root, "timing", name="AutoBeat")
     for bt in beat_times:
         ET.SubElement(timing, "marker", timeMS=str(int(bt * 1000)))
+
+    # optional secondary timing track for musical sections
+    if sections:
+        timing_sec = ET.SubElement(root, "timing", name="Sections")
+        for sec in sections:
+            attrs = {"timeMS": str(int(sec["time"] * 1000))}
+            label = sec.get("label")
+            if label:
+                attrs["label"] = label
+            ET.SubElement(timing_sec, "marker", **attrs)
 
     preset_cfg = PRESET_MAP.get(preset, PRESET_MAP["solid_pulse"])
 


### PR DESCRIPTION
## Summary
- derive musical sections (Intro/Verse/Chorus) by clustering beat-synchronous onset strengths
- emit a new `Sections` timing track with labeled markers alongside existing beats
- plumb section markers through the Flask app and add regression test for timing track

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a843917083309d6b481a90b51b77