### PR TITLE
Improve upload validation and error reporting

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -1,19 +1,50 @@
 const form = document.getElementById('genForm');
 const out = document.getElementById('result');
+const MAX_MB = 25;
+const ALLOWED_XML = ['text/xml', 'application/xml'];
+const ALLOWED_AUDIO = ['audio/mpeg', 'audio/wav', 'audio/x-wav', 'audio/aac', 'audio/m4a', 'audio/mp4'];
+
+function showError(msg) {
+  out.style.color = 'red';
+  out.textContent = 'Error: ' + msg;
+}
+
+function showMessage(msg) {
+  out.style.color = '';
+  out.textContent = msg;
+}
 
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
-  out.textContent = "Processing... (this can take a moment for large MP3s)";
+
+  const layoutFile = form.layout.files[0];
+  const audioFile = form.audio.files[0];
+  const maxBytes = MAX_MB * 1024 * 1024;
+
+  if (layoutFile.size > maxBytes || audioFile.size > maxBytes) {
+    showError(`Files must be smaller than ${MAX_MB}MB.`);
+    return;
+  }
+  if (!ALLOWED_XML.includes(layoutFile.type)) {
+    showError('Unsupported layout file type.');
+    return;
+  }
+  if (!ALLOWED_AUDIO.includes(audioFile.type)) {
+    showError('Unsupported audio file type.');
+    return;
+  }
+
+  showMessage('Processing... (this can take a moment for large MP3s)');
   const fd = new FormData(form);
   try {
-    const r = await fetch('/generate', { method:'POST', body: fd });
+    const r = await fetch('/generate', { method: 'POST', body: fd });
     const j = await r.json();
     if (!j.ok) {
-      out.textContent = "Error: " + (j.error || "Unknown");
+      showError(j.error || 'Unknown');
       return;
     }
-    out.textContent = JSON.stringify(j, null, 2) + "\n\nDownload: " + location.origin + j.downloadUrl;
+    showMessage(JSON.stringify(j, null, 2) + "\n\nDownload: " + location.origin + j.downloadUrl);
   } catch (err) {
-    out.textContent = "Network error: " + err.message;
+    showError('Network error: ' + err.message);
   }
 });

--- a/xlights_seq/config.py
+++ b/xlights_seq/config.py
@@ -2,7 +2,7 @@ import os
 
 class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY", "devkey")
-    MAX_CONTENT_LENGTH = 100 * 1024 * 1024  # 100MB
+    MAX_CONTENT_LENGTH = 25 * 1024 * 1024  # 25MB
     UPLOAD_FOLDER = os.path.abspath("uploads")
     OUTPUT_FOLDER = os.path.abspath("generated")
     ALLOWED_XML = {"xml"}


### PR DESCRIPTION
## Summary
- return JSON errors for XML parsing, audio analysis, and oversized uploads
- validate file extensions and MIME types before processing
- surface validation errors in the browser with size/type checks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897aa91d2148330b6f2c1a98641515f