### PR TITLE
Add health endpoint and request logging

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,33 @@
+import importlib
+import pytest
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    log_file = tmp_path / "app.log"
+    monkeypatch.setenv("LOG_FILE", str(log_file))
+    import xlights_seq.config as config
+    importlib.reload(config)
+    import app
+    importlib.reload(app)
+    with app.app.test_client() as client:
+        yield client, log_file
+
+
+def test_health_endpoint(client):
+    test_client, _ = client
+    resp = test_client.get("/health")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"ok": True}
+
+
+def test_logging_to_file(client):
+    test_client, log_file = client
+    test_client.get("/health")
+    contents = log_file.read_text()
+    assert "Started GET /health" in contents
+    assert "Completed GET /health" in contents

--- a/xlights_seq/config.py
+++ b/xlights_seq/config.py
@@ -7,3 +7,4 @@ class Config:
     OUTPUT_FOLDER = os.path.abspath("generated")
     ALLOWED_XML = {"xml"}
     ALLOWED_AUDIO = {"mp3","wav","m4a","aac"}
+    LOG_FILE = os.environ.get("LOG_FILE", os.path.abspath("app.log"))


### PR DESCRIPTION
## Summary
- add health check endpoint returning `{ok: true}`
- log request start, completion, durations, and errors to configurable file
- add tests for health route and logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897ac5c205c8330901611f208b45818