### PR TITLE
Add tests and CI for sequence generator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: tests
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask==3.0.3
 librosa==0.10.2.post1
 soundfile==0.12.1
 numpy==1.26.4
+pytest==8.2.0

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,22 @@
+import numpy as np
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import librosa
+from xlights_seq.audio import analyze_beats
+
+
+def test_analyze_beats_mocked(monkeypatch):
+    monkeypatch.setattr(librosa, "load", lambda path, mono: (np.zeros(4), 22050))
+    monkeypatch.setattr(librosa.beat, "beat_track", lambda y, sr, trim: (120.0, np.array([0,1,2,3])))
+    monkeypatch.setattr(librosa, "frames_to_time", lambda frames, sr: np.array([0.0,0.5,1.0,1.5]))
+    monkeypatch.setattr(librosa.onset, "onset_strength", lambda y, sr: np.array([0.1,0.2,0.8,0.4]))
+    monkeypatch.setattr(librosa, "get_duration", lambda y, sr: 2.0)
+
+    result = analyze_beats("dummy.wav")
+    assert result["bpm"] == 120.0
+    assert result["beat_times"] == [0.0,0.5,1.0,1.5]
+    assert result["duration_s"] == 2.0
+    assert result["sections"] == [
+        {"time": 0.5, "label": "Verse"},
+        {"time": 1.0, "label": "Chorus"},
+    ]

--- a/tests/test_generator_structure.py
+++ b/tests/test_generator_structure.py
@@ -1,0 +1,26 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from xlights_seq.generator import build_rgbeffects
+from xlights_seq.parsers import ModelInfo
+
+
+def test_build_rgbeffects_structure():
+    models = [ModelInfo(name="m1"), ModelInfo(name="m2")]
+    beat_times = [0.0, 0.5]
+    tree = build_rgbeffects(models, beat_times, duration_ms=1000, preset="solid_pulse")
+    root = tree.getroot()
+    assert root.tag == "xrgb"
+
+    timing = root.find("timing[@name='AutoBeat']")
+    markers = timing.findall("marker")
+    assert [m.get("timeMS") for m in markers] == ["0", "500"]
+
+    models_elems = root.findall("model")
+    assert len(models_elems) == 2
+    for mdl in models_elems:
+        layer = mdl.find("effectLayer")
+        effects = layer.findall("effect")
+        assert len(effects) == 2
+        assert effects[0].get("startMS") == "0" and effects[0].get("endMS") == "500"
+        assert effects[1].get("startMS") == "500" and effects[1].get("endMS") == "1000"
+        assert all(eff.get("type") == "On" for eff in effects)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,19 @@
+import xml.etree.ElementTree as ET
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from xlights_seq.parsers import parse_models, ModelInfo
+
+
+def test_parse_models_deduplicate(tmp_path):
+    xml = ET.Element("root")
+    ET.SubElement(xml, "model", name="Tree", StringCount="10")
+    ET.SubElement(xml, "model", Model="Tree", Strings="8")
+    ET.SubElement(xml, "model", name="Star", Nodes="50")
+    ET.ElementTree(xml).write(tmp_path / "models.xml")
+
+    models = parse_models(str(tmp_path / "models.xml"))
+    assert [m.name for m in models] == ["Tree", "Star"]
+    tree = models[0]
+    star = models[1]
+    assert tree.strings == 10 and tree.nodes is None
+    assert star.strings is None and star.nodes == 50


### PR DESCRIPTION
## Summary
- add pytest dependency
- test parse_models XML parsing and dedupe
- mock analyze_beats to validate output structure
- test build_rgbeffects timing and effect layout
- add GitHub Actions workflow to run pytest on pushes and PRs

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897ae868d4083309bace2f1cedfe7b8