### PR TITLE
Add generation details and spinner to UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -127,7 +127,9 @@ def generate():
         "ok": True,
         "jobId": job,
         "bpm": bpm_val,
+        "durationMs": duration_ms,
         "modelCount": len(models),
+        "modelNames": [m.name for m in models],
         "downloadUrl": f"/download/{job}"
     })
 

--- a/static/main.js
+++ b/static/main.js
@@ -1,5 +1,6 @@
 const form = document.getElementById('genForm');
 const out = document.getElementById('result');
+const spinner = document.getElementById('spinner');
 const MAX_MB = 25;
 const ALLOWED_XML = ['text/xml', 'application/xml'];
 const ALLOWED_AUDIO = ['audio/mpeg', 'audio/wav', 'audio/x-wav', 'audio/aac', 'audio/m4a', 'audio/mp4'];
@@ -35,6 +36,7 @@ form.addEventListener('submit', async (e) => {
   }
 
   showMessage('Processing... (this can take a moment for large MP3s)');
+  spinner.style.display = 'block';
   const fd = new FormData(form);
   try {
     const r = await fetch('/generate', { method: 'POST', body: fd });
@@ -43,8 +45,12 @@ form.addEventListener('submit', async (e) => {
       showError(j.error || 'Unknown');
       return;
     }
-    showMessage(JSON.stringify(j, null, 2) + "\n\nDownload: " + location.origin + j.downloadUrl);
+    const durationSec = (j.durationMs / 1000).toFixed(2);
+    const modelsList = (j.modelNames || []).map(n => '- ' + n).join('\n');
+    showMessage(`Detected BPM: ${j.bpm ?? 'n/a'}\nDuration: ${durationSec}s\nModels (${j.modelCount}):\n${modelsList}\n\nDownload: ${location.origin + j.downloadUrl}`);
   } catch (err) {
     showError('Network error: ' + err.message);
+  } finally {
+    spinner.style.display = 'none';
   }
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,8 @@
     label { display:block; margin-top: 1rem; font-weight: 600; }
     button { margin-top: 1rem; padding: .6rem 1rem; border-radius: 6px; border: 1px solid #444; background:#fff; cursor:pointer; }
     pre { background:#fafafa; border:1px solid #eee; padding:1rem; border-radius:8px; overflow:auto; }
+    .spinner { border:4px solid #f3f3f3; border-top:4px solid #444; border-radius:50%; width:24px; height:24px; animation:spin 1s linear infinite; display:none; margin-top:1rem; }
+    @keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
   </style>
 </head>
 <body>
@@ -39,6 +41,7 @@
   </div>
 
   <h2>Result</h2>
+  <div id="spinner" class="spinner"></div>
   <pre id="result">Waiting...</pre>
 
   <script src="/static/main.js"></script>


### PR DESCRIPTION
## Summary
- Display detected BPM, duration, model count and names after generation
- Add a progress spinner during processing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897b2e2a7a08330b07e20d07d66523d