### PR TITLE
Add manual BPM and start offset controls

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -31,7 +31,7 @@
         </select>
       </label>
       <label>Manual BPM
-        <input name="bpm" type="number" step="any">
+        <input name="manual_bpm" type="number" step="any">
       </label>
       <label>Start Offset (ms)
         <input name="start_offset_ms" type="number" step="1" value="0">


### PR DESCRIPTION
## Summary
- Add manual BPM and start offset fields to form
- Generate beat grid from manual BPM and apply start offset
- Store manual BPM and offset in metadata

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897b4947b148330a64e128b903f64bc