### PR TITLE
Improve result panel with download option and error banner

### DIFF
--- a/app.py
+++ b/app.py
@@ -125,6 +125,7 @@ def generate():
         "ok": True,
         "jobId": job,
         "bpm": bpm_val,
+        "manualBpm": manual_bpm,
         "durationMs": duration_ms,
         "modelCount": len(models),
         "modelNames": [m.name for m in models],

--- a/static/main.js
+++ b/static/main.js
@@ -6,13 +6,35 @@ const ALLOWED_XML = ['text/xml', 'application/xml'];
 const ALLOWED_AUDIO = ['audio/mpeg', 'audio/wav', 'audio/x-wav', 'audio/aac', 'audio/m4a', 'audio/mp4'];
 
 function showError(msg) {
-  out.style.color = 'red';
-  out.textContent = 'Error: ' + msg;
+  out.className = 'error-banner';
+  out.textContent = msg;
 }
 
 function showMessage(msg) {
-  out.style.color = '';
+  out.className = '';
   out.textContent = msg;
+}
+
+function showResult(j) {
+  const minutes = Math.floor(j.durationMs / 60000);
+  const seconds = Math.floor((j.durationMs % 60000) / 1000)
+    .toString()
+    .padStart(2, '0');
+  const models = j.modelNames || [];
+  const firstTen = models.slice(0, 10);
+  let modelText = firstTen.join(', ');
+  if (models.length > 10) {
+    modelText += ` +${models.length - 10} more`;
+  }
+  const downloadUrl = location.origin + j.downloadUrl;
+  out.className = 'result-panel';
+  out.innerHTML = `
+    <p><strong>Detected BPM:</strong> ${j.bpm ?? 'n/a'}</p>
+    <p><strong>Manual BPM:</strong> ${j.manualBpm ?? 'n/a'}</p>
+    <p><strong>Duration:</strong> ${minutes}:${seconds}</p>
+    <p><strong>Models (${j.modelCount}):</strong> ${modelText}</p>
+    <a class="download-btn" href="${downloadUrl}">Download</a>
+  `;
 }
 
 form.addEventListener('submit', async (e) => {
@@ -45,12 +67,13 @@ form.addEventListener('submit', async (e) => {
       showError(j.error || 'Unknown');
       return;
     }
-    const durationSec = (j.durationMs / 1000).toFixed(2);
-    const modelsList = (j.modelNames || []).map(n => '- ' + n).join('\n');
-    showMessage(`Detected BPM: ${j.bpm ?? 'n/a'}\nDuration: ${durationSec}s\nModels (${j.modelCount}):\n${modelsList}\n\nDownload: ${location.origin + j.downloadUrl}`);
+    showResult(j);
   } catch (err) {
     showError('Network error: ' + err.message);
   } finally {
     spinner.style.display = 'none';
   }
 });
+
+// Initial message
+showMessage('Waiting...');

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,9 @@
     .card { border: 1px solid #ddd; padding: 1rem; border-radius: 8px; max-width: 720px; }
     label { display:block; margin-top: 1rem; font-weight: 600; }
     button { margin-top: 1rem; padding: .6rem 1rem; border-radius: 6px; border: 1px solid #444; background:#fff; cursor:pointer; }
-    pre { background:#fafafa; border:1px solid #eee; padding:1rem; border-radius:8px; overflow:auto; }
+    .result-panel { background:#fafafa; border:1px solid #eee; padding:1rem; border-radius:8px; max-width:720px; }
+    .error-banner { background:#fdd; border:1px solid #d00; color:#900; padding:.6rem 1rem; border-radius:6px; max-width:720px; }
+    .download-btn { display:inline-block; margin-top:1rem; padding:1rem 2rem; font-size:1.1rem; background:#28a745; color:#fff; text-decoration:none; border-radius:8px; }
     .spinner { border:4px solid #f3f3f3; border-top:4px solid #444; border-radius:50%; width:24px; height:24px; animation:spin 1s linear infinite; display:none; margin-top:1rem; }
     @keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
   </style>
@@ -42,7 +44,7 @@
 
   <h2>Result</h2>
   <div id="spinner" class="spinner"></div>
-  <pre id="result">Waiting...</pre>
+  <div id="result"></div>
 
   <script src="/static/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- show helpful result panel after generation including BPM, duration, model names and big download button
- add error banner styling for failed requests
- return manual BPM from `/generate` API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897b5eae35c8330b2224108618c214c