### PR TITLE
Add docker healthcheck and curl dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3.11-slim
 WORKDIR /app
 # System deps for audio processing
-RUN apt-get update && apt-get install -y --no-install-recommends     ffmpeg libsndfile1  && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg libsndfile1 curl \
+    && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,11 @@ services:
     restart: unless-stopped
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:5000/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
 
   watchtower:
     image: containrrr/watchtower


### PR DESCRIPTION
## Summary
- add service healthcheck to docker-compose
- install curl in Dockerfile for healthcheck probing
- ensure `/health` endpoint responds with `{ok: true}`

## Testing
- `pytest`
- `docker compose config` *(fails: command not found: docker)*
- `docker build .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_6897b9dc589883309e6bf88b996af308