### PR TITLE
Tune effect parameters by model complexity

### DIFF
--- a/tests/test_generator_mapping.py
+++ b/tests/test_generator_mapping.py
@@ -20,21 +20,25 @@ def test_bars_count_proportional():
     bars1 = m1_effect.find("./param[@name='Bars']").get("value")
     assert bars1 == "8"
 
-    # Second model uses nodes to determine bar count (200 // 50 = 4)
+    # Second model falls back to default when strings are missing
     m2_effect = model_elems[1].find(".//effect")
     bars2 = m2_effect.find("./param[@name='Bars']").get("value")
-    assert bars2 == "4"
+    assert bars2 == "8"
 
 
-def test_skip_small_model_for_heavy_effect():
+def test_small_model_uses_simple_effect_for_heavy_preset():
     small = ModelInfo(name="small", nodes=5)
     big = ModelInfo(name="big", nodes=100)
     beat_times = [0, 1]
     tree = build_rgbeffects([small, big], beat_times, duration_ms=1000, preset="meteor")
     root = tree.getroot()
     names = [m.get("name") for m in root.findall("model")]
-    assert "small" not in names
+    assert "small" in names
     assert "big" in names
+    small_effect = root.find("./model[@name='small']//effect")
+    assert small_effect.get("type") == "On"
+    big_effect = root.find("./model[@name='big']//effect")
+    assert big_effect.get("type") == "Meteor"
 
 
 def test_sections_timing_track():


### PR DESCRIPTION
## Summary
- Scale Bars effect by model string count with clamping
- Swap heavy presets for simple On effect on tiny models
- Adjust tests for new per-model tuning behavior

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_6897bd25031883308cf487ebcbc4d70e