### PR TITLE
Show application version in web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,5 @@ docker compose up --build -d
 ## Notes
 - Dockerfile includes `ffmpeg` + `libsndfile1` for audio analysis (librosa).
 - Health endpoint: `GET /health` → `{ "ok": true }`
+- Version endpoint: `GET /version` → `{ "version": "<value>" }`
+- Set `APP_VERSION` environment variable to have the web UI display the current version (defaults to `dev`).

--- a/app.py
+++ b/app.py
@@ -48,11 +48,16 @@ def handle_exception(e):
 
 @app.get("/")
 def index():
-    return render_template("index.html")
+    return render_template("index.html", version=app.config["VERSION"])
 
 @app.get("/health")
 def health():
     return jsonify(ok=True)
+
+
+@app.get("/version")
+def version():
+    return jsonify(version=app.config["VERSION"])
 
 @app.post("/generate")
 def generate():

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,6 +14,7 @@
     .download-btn { display:inline-block; margin-top:1rem; padding:1rem 2rem; font-size:1.1rem; background:#28a745; color:#fff; text-decoration:none; border-radius:8px; }
     .spinner { border:4px solid #f3f3f3; border-top:4px solid #444; border-radius:50%; width:24px; height:24px; animation:spin 1s linear infinite; display:none; margin-top:1rem; }
     @keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
+    .version { margin-top:2rem; color:#666; font-size:0.9rem; }
   </style>
 </head>
 <body>
@@ -46,6 +47,8 @@
   <h2>Result</h2>
   <div id="spinner" class="spinner"></div>
   <div id="result"></div>
+
+  <div class="version">Version: {{ version }}</div>
 
   <script src="/static/main.js"></script>
 </body>

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,30 @@
+import importlib
+import pytest
+import os, sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    log_file = tmp_path / "app.log"
+    monkeypatch.setenv("APP_VERSION", "1.2.3")
+    monkeypatch.setenv("LOG_FILE", str(log_file))
+    import xlights_seq.config as config
+    importlib.reload(config)
+    import app
+    importlib.reload(app)
+    with app.app.test_client() as client:
+        yield client
+
+
+def test_version_endpoint(client):
+    resp = client.get("/version")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"version": "1.2.3"}
+
+
+def test_version_in_index(client):
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert b"Version: 1.2.3" in resp.data

--- a/xlights_seq/config.py
+++ b/xlights_seq/config.py
@@ -8,3 +8,4 @@ class Config:
     ALLOWED_XML = {"xml"}
     ALLOWED_AUDIO = {"mp3","wav","m4a","aac"}
     LOG_FILE = os.environ.get("LOG_FILE", os.path.abspath("app.log"))
+    VERSION = os.environ.get("APP_VERSION", "dev")


### PR DESCRIPTION
## Summary
- Display running application version on the main page
- Expose `/version` endpoint and config flag `APP_VERSION`
- Document and test version reporting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897c38415d88330b1f1f2699c07d0f7