### PR TITLE
feat: compute sections timing track from audio

### DIFF
--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -14,9 +14,7 @@ def test_analyze_beats_mocked(monkeypatch):
 
     result = analyze_beats("dummy.wav")
     assert result["bpm"] == 120.0
-    assert result["beat_times"] == [0.0,0.5,1.0,1.5]
+    assert result["beat_times"] == [0.0, 0.5, 1.0, 1.5]
+    assert result["onset_strength"] == [0.1, 0.2, 0.8, 0.4]
     assert result["duration_s"] == 2.0
-    assert result["sections"] == [
-        {"time": 0.5, "label": "Verse"},
-        {"time": 1.0, "label": "Chorus"},
-    ]
+    assert result["sections"] == [{"time": 1.0, "label": "Section 2"}]

--- a/xlights_seq/audio.py
+++ b/xlights_seq/audio.py
@@ -3,15 +3,27 @@ import numpy as np
 
 
 def analyze_beats(audio_path: str):
-    """Analyze an audio file for beat times and coarse section changes.
+    """Analyze an audio file for beat times and musical sections.
 
-    In addition to the per-beat timing returned by ``librosa.beat.beat_track``,
-    this function estimates high-level sections ("Intro", "Verse", "Chorus") by
-    grouping beats based on onset strength.  Section boundaries are marked when
-    the beat-synchronous onset strength crosses quantile thresholds.
+    Besides tempo and beat locations this function also computes an
+    onset-strength envelope and performs a very coarse segmentation by
+    looking for large increases in that envelope.  Each detected jump
+    marks the beginning of a new "Section".  The results are suitable for
+    driving a secondary timing track in xLights.
 
-    Returns a dictionary with keys ``bpm``, ``beat_times``, ``duration_s`` and
-    ``sections`` (a list of ``{"time": float, "label": str}``).
+    Returns a dictionary with the following keys:
+
+    ``bpm``
+        Estimated tempo in beats-per-minute.
+    ``beat_times``
+        List of beat locations (seconds).
+    ``onset_strength``
+        Beat-synchronous onset strength values.
+    ``duration_s``
+        Total duration of the audio in seconds.
+    ``sections``
+        List of ``{"time": float, "label": str}`` entries marking when a
+        new section starts.
     """
 
     # Load mono for speed
@@ -21,31 +33,29 @@ def analyze_beats(audio_path: str):
     tempo, beat_frames = librosa.beat.beat_track(y=y, sr=sr, trim=True)
     beat_times = librosa.frames_to_time(beat_frames, sr=sr)
 
-    # Onset strength envelope to gauge musical intensity
+    # Compute onset strength and sample it at the beat locations
     onset_env = librosa.onset.onset_strength(y=y, sr=sr)
-    # Sample the onset envelope at beat locations
     beat_env = onset_env[beat_frames]
 
     sections = []
-    if len(beat_env) > 0:
-        # Quantile-based grouping into three rough energy bands
-        q1, q2 = np.quantile(beat_env, [1 / 3, 2 / 3])
-        labels = np.digitize(beat_env, [q1, q2])  # 0,1,2 -> low, mid, high
-        section_names = ["Intro", "Verse", "Chorus"]
-
-        prev_label = labels[0]
-        for i in range(1, len(labels)):
-            if labels[i] != prev_label:
+    if len(beat_env) > 1:
+        # Look for large increases in onset strength to mark new sections
+        diff_env = np.diff(beat_env, prepend=beat_env[0])
+        threshold = 0.5 * np.max(beat_env)
+        section_no = 2  # section 1 starts at t=0
+        for i in range(1, len(beat_env)):
+            if diff_env[i] > threshold:
                 sections.append({
                     "time": float(beat_times[i]),
-                    "label": section_names[labels[i]],
+                    "label": f"Section {section_no}",
                 })
-                prev_label = labels[i]
+                section_no += 1
 
     duration = float(librosa.get_duration(y=y, sr=sr))
     return {
         "bpm": float(tempo),
         "beat_times": beat_times.tolist(),
+        "onset_strength": beat_env.tolist(),
         "duration_s": duration,
         "sections": sections,
     }


### PR DESCRIPTION
## Summary
- detect coarse musical sections from onset strength while analyzing audio
- expose onset strength data and section markers for downstream use

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897c5010b5c8330bc023c2a9c24268d