### PR TITLE
Guard audio analysis with timeout

### DIFF
--- a/xlights_seq/config.py
+++ b/xlights_seq/config.py
@@ -9,3 +9,4 @@ class Config:
     ALLOWED_AUDIO = {"mp3","wav","m4a","aac"}
     LOG_FILE = os.environ.get("LOG_FILE", os.path.abspath("app.log"))
     VERSION = os.environ.get("APP_VERSION", "dev")
+    ANALYSIS_TIMEOUT = int(os.environ.get("ANALYSIS_TIMEOUT", "30"))


### PR DESCRIPTION
## Summary
- Add configurable analysis timeout and run beat detection in a worker thread.
- Fall back to a 120 BPM beat grid when audio analysis exceeds the timeout.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897caa10f508330af0c3d2e470113b7