### PR TITLE
Add JSON request logger

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,43 @@
+import logging
+import json
+import os
+from datetime import datetime, timezone
+
+
+class JsonFormatter(logging.Formatter):
+    """Format log records as JSON."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        log = {
+            "time": datetime.fromtimestamp(record.created, timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "level": record.levelname,
+            "message": record.getMessage(),
+        }
+        # Include any custom attributes added via "extra"
+        for key, value in record.__dict__.items():
+            if key in {
+                "path",
+                "ip",
+                "status",
+                "duration_ms",
+                "error",
+                "layout_bytes",
+                "audio_bytes",
+                "bpm",
+            }:
+                log[key] = value
+        return json.dumps(log)
+
+
+def get_json_logger(log_file: str) -> logging.Logger:
+    """Create a logger that writes JSON lines to the given file."""
+    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+    logger = logging.getLogger("app")
+    logger.setLevel(logging.INFO)
+    logger.handlers = []
+    handler = logging.FileHandler(log_file)
+    handler.setFormatter(JsonFormatter())
+    logger.addHandler(handler)
+    return logger

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -2,6 +2,7 @@ import importlib
 import pytest
 import os
 import sys
+import json
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
@@ -28,6 +29,8 @@ def test_health_endpoint(client):
 def test_logging_to_file(client):
     test_client, log_file = client
     test_client.get("/health")
-    contents = log_file.read_text()
-    assert "Started GET /health" in contents
-    assert "Completed GET /health" in contents
+    lines = [json.loads(line) for line in log_file.read_text().splitlines()]
+    assert lines[0]["message"] == "request_started"
+    assert lines[0]["path"] == "/health"
+    assert lines[1]["message"] == "request_completed"
+    assert lines[1]["status"] == 200

--- a/xlights_seq/config.py
+++ b/xlights_seq/config.py
@@ -7,6 +7,8 @@ class Config:
     OUTPUT_FOLDER = os.path.abspath("generated")
     ALLOWED_XML = {"xml"}
     ALLOWED_AUDIO = {"mp3","wav","m4a","aac"}
-    LOG_FILE = os.environ.get("LOG_FILE", os.path.abspath("app.log"))
+    LOG_FILE = os.environ.get(
+        "LOG_FILE", os.path.join(OUTPUT_FOLDER, "app.log")
+    )
     VERSION = os.environ.get("APP_VERSION", "dev")
     ANALYSIS_TIMEOUT = int(os.environ.get("ANALYSIS_TIMEOUT", "30"))


### PR DESCRIPTION
## Summary
- Add JSON logging utility to write structured logs to `generated/app.log`
- Trace each request with path, IP, status, and duration
- Record `/generate` job details including file sizes and BPM

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897cdad721c83308f8b34106d7e44a0