### PR TITLE
Add customizable color palette

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -40,6 +40,9 @@
       <label>Start Offset (ms)
         <input name="start_offset_ms" type="number" step="1" value="0">
       </label>
+      <label>Palette (comma-separated hex colors)
+        <textarea name="palette" rows="2" placeholder="#FF0000,#00FF00,#0000FF"></textarea>
+      </label>
       <button type="submit">Generate Sequence</button>
     </form>
   </div>

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -25,3 +25,19 @@ def test_effect_spans_and_params():
         assert eff.get("endMS") == str(end)
         assert eff.find("./param[@name='Color1']") is not None
 
+
+def test_custom_palette_overrides_default():
+    models = [ModelInfo(name="tree")]
+    beat_times = [0.0, 1.0, 2.0, 3.0]
+    duration_ms = 4000
+    custom = ["#111111", "#222222", "#333333"]
+
+    tree = build_rgbeffects(
+        models, beat_times, duration_ms, preset="solid_pulse", palette=custom
+    )
+    root = tree.getroot()
+    effects = root.find("./model").findall(".//effect")
+    colors = [e.find("./param[@name='Color1']").get("value") for e in effects]
+
+    assert colors[1:] == ["#222222", "#333333", "#111111"]
+

--- a/xlights_seq/generator.py
+++ b/xlights_seq/generator.py
@@ -29,7 +29,7 @@ HEAVY_PRESETS = {"meteor"}
 SMALL_MODEL_NODES = 25
 
 
-def build_rgbeffects(models, beat_times, duration_ms, preset: str, sections=None):
+def build_rgbeffects(models, beat_times, duration_ms, preset: str, sections=None, palette=None):
     """Generate an xLights RGB effects file using a preset.
 
     Parameters
@@ -45,6 +45,9 @@ def build_rgbeffects(models, beat_times, duration_ms, preset: str, sections=None
     sections : list[dict], optional
         Optional list of section markers as returned by ``analyze_beats``.
         Each item must contain ``time`` (seconds) and ``label``.
+    palette : list[str], optional
+        Optional list of hex colors (e.g. ``"#FF0000"``) used for Color1 cycling.
+        If not provided, falls back to the module ``PALETTE``.
     """
 
     root = ET.Element("xrgb", version="2024.05", showDir=".")
@@ -66,6 +69,7 @@ def build_rgbeffects(models, beat_times, duration_ms, preset: str, sections=None
     preset_cfg = PRESETS.get(preset, PRESETS["solid_pulse"])
 
     # simple per-beat effect per model
+    active_palette = palette or PALETTE
     for m in models:
         mdl = ET.SubElement(root, "model", name=m.name)
         layer = ET.SubElement(mdl, "effectLayer", name="Layer 1")
@@ -81,7 +85,7 @@ def build_rgbeffects(models, beat_times, duration_ms, preset: str, sections=None
             eff_params = preset_cfg.get("params", {}).copy()
 
             # rotating color palette
-            color = PALETTE[i % len(PALETTE)]
+            color = active_palette[i % len(active_palette)]
             is_downbeat = i % DOWNBEAT_INTERVAL == 0
             if is_downbeat:
                 color = DOWNBEAT_COLOR


### PR DESCRIPTION
## Summary
- Expose textarea input for comma-separated hex colors in the web form
- Parse user-supplied palette in `/generate` and forward to the sequence generator
- Extend generator to accept optional palettes and add test coverage for custom colors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897d4bcae9083308aeef67447e20c2d