### PR TITLE
Add export format selection and networks upload options

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -27,6 +27,16 @@
       <label>Audio File
         <input name="audio" type="file" accept=".mp3,.wav,.m4a,.aac" required>
       </label>
+      <label>Export format
+        <select name="export_format">
+          <option value="rgbeffects_xml" selected>rgbeffects.xml</option>
+          <option value="xsq">XSQ (single file)</option>
+          <option value="xsqz">XSQZ (zip package)</option>
+        </select>
+      </label>
+      <label>Networks (optional, xlights_networks.xml)
+        <input name="networks" type="file" accept=".xml">
+      </label>
       <p>Up to 100MB.</p>
       <label>Effect Preset
         <select name="preset">


### PR DESCRIPTION
## Summary
- add export format selector and optional networks file field to the generator form
- show selected export format and direct download link in result panel
- support export format and networks file on the backend and serve proper artifact

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897de354ec08330b57c8c30dea8af0d