### PR TITLE
Handle networks input and use canonical rgbeffects name

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -6,7 +6,7 @@ const MAX_MB = 25;
 const ALLOWED_XML = ['text/xml', 'application/xml'];
 const ALLOWED_AUDIO = ['audio/mpeg', 'audio/wav', 'audio/x-wav', 'audio/aac', 'audio/m4a', 'audio/mp4'];
 const EXPORT_FORMAT_LABELS = {
-  rgbeffects_xml: 'rgbeffects.xml',
+  rgbeffects_xml: 'xlights_rgbeffects.xml',
   xsq: 'XSQ (single file)',
   xsqz: 'XSQZ (zip package)'
 };

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,7 +21,7 @@
   <h1>xLights Auto-Sequence</h1>
   <div class="card">
     <form id="genForm" enctype="multipart/form-data">
-      <label>Layout (xlights_rgbeffect.xml)
+      <label>Layout (xlights_rgbeffects.xml)
         <input name="layout" type="file" accept=".xml" required>
       </label>
       <label>Audio File
@@ -29,7 +29,7 @@
       </label>
       <label>Export format
         <select name="export_format">
-          <option value="rgbeffects_xml" selected>rgbeffects.xml</option>
+          <option value="rgbeffects_xml" selected>xlights_rgbeffects.xml</option>
           <option value="xsq">XSQ (single file)</option>
           <option value="xsqz">XSQZ (zip package)</option>
         </select>


### PR DESCRIPTION
## Summary
- Allow optional networks upload in `/generate`, validating extension and size before saving
- Write RGBeffects output using canonical `xlights_rgbeffects.xml` name and update download handling
- Reflect new filename in frontend labels

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897df60d31883308b92fb497c64f553