### PR TITLE
Add tests for xsq and xsqz export

### DIFF
--- a/tests/test_xsq_export.py
+++ b/tests/test_xsq_export.py
@@ -1,0 +1,14 @@
+import zipfile, os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from xlights_seq.xsq_package import write_xsq, write_xsqz
+
+
+def test_xsq_and_xsqz(tmp_path):
+    rgbeffects = tmp_path/"xlights_rgbeffects.xml"
+    rgbeffects.write_text("<xrgb></xrgb>", encoding="utf-8")
+    xsq = tmp_path/"out.xsq"; xsqz = tmp_path/"out.xsqz"
+    write_xsq(str(xsq), str(rgbeffects))
+    assert xsq.exists() and xsq.read_text(encoding="utf-8").startswith("<xrgb")
+    write_xsqz(str(xsqz), str(rgbeffects), None, [])
+    with zipfile.ZipFile(xsqz) as z:
+        assert "xlights_rgbeffects.xml" in z.namelist()


### PR DESCRIPTION
## Summary
- add regression test for xsq and xsqz writing utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897e9153d6c833094973ab36af816e2