### PR TITLE
Add dynamic versioning and expose app version

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,12 +7,16 @@ from xlights_seq.parsers import parse_models, parse_tree, flatten_models
 from xlights_seq.audio import analyze_beats
 from xlights_seq.generator import build_rgbeffects, write_rgbeffects
 from xlights_seq.xsq_package import write_xsq, write_xsqz
+from xlights_seq.versioning import build_version
 from logger import get_json_logger
 
 OFFLINE = os.environ.get("OFFLINE", "1") == "1"
 
+APP_VERSION = build_version()
+
 app = Flask(__name__)
 app.config.from_object(Config)
+app.config["VERSION"] = APP_VERSION
 os.makedirs(app.config["UPLOAD_FOLDER"], exist_ok=True)
 os.makedirs(app.config["OUTPUT_FOLDER"], exist_ok=True)
 
@@ -78,7 +82,7 @@ def index():
 
 @app.get("/health")
 def health():
-    return jsonify(ok=True)
+    return jsonify(ok=True, version=APP_VERSION)
 
 
 @app.get("/version")
@@ -283,6 +287,7 @@ def generate():
                 "export_format": export_format,
                 "has_networks": bool(networks_path),
                 "has_media": os.path.exists(audio_path),
+                "version": APP_VERSION,
             },
             f,
             indent=2,

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -23,7 +23,8 @@ def test_health_endpoint(client):
     test_client, _ = client
     resp = test_client.get("/health")
     assert resp.status_code == 200
-    assert resp.get_json() == {"ok": True}
+    import app
+    assert resp.get_json() == {"ok": True, "version": app.APP_VERSION}
 
 
 def test_logging_to_file(client):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,12 +4,22 @@ import os, sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
+EXPECTED_VERSION = "build.5+abcdef1"
+
 
 @pytest.fixture
 def client(tmp_path, monkeypatch):
     log_file = tmp_path / "app.log"
-    monkeypatch.setenv("APP_VERSION", "1.2.3")
     monkeypatch.setenv("LOG_FILE", str(log_file))
+    monkeypatch.delenv("APP_VERSION", raising=False)
+    monkeypatch.setenv("GITHUB_SHA", "abcdef1234567")
+    monkeypatch.setenv("GITHUB_RUN_NUMBER", "5")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "")
+    monkeypatch.delenv("GITHUB_REF_TYPE", raising=False)
+    monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
+    monkeypatch.delenv("PR_NUMBER", raising=False)
+    import xlights_seq.versioning as versioning
+    importlib.reload(versioning)
     import xlights_seq.config as config
     importlib.reload(config)
     import app
@@ -21,10 +31,16 @@ def client(tmp_path, monkeypatch):
 def test_version_endpoint(client):
     resp = client.get("/version")
     assert resp.status_code == 200
-    assert resp.get_json() == {"version": "1.2.3"}
+    assert resp.get_json() == {"version": EXPECTED_VERSION}
 
 
 def test_version_in_index(client):
     resp = client.get("/")
     assert resp.status_code == 200
-    assert b"Version: 1.2.3" in resp.data
+    assert f"Version: {EXPECTED_VERSION}".encode() in resp.data
+
+
+def test_health_includes_version(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"ok": True, "version": EXPECTED_VERSION}

--- a/xlights_seq/versioning.py
+++ b/xlights_seq/versioning.py
@@ -1,0 +1,19 @@
+import os, datetime
+
+
+def build_version():
+    # Prefer CI metadata
+    pr = os.environ.get("GITHUB_EVENT_NAME") == "pull_request"
+    pr_num = os.environ.get("PR_NUMBER") or os.environ.get("GITHUB_REF_NAME")
+    sha = (os.environ.get("GITHUB_SHA") or "")[:7]
+    run = os.environ.get("GITHUB_RUN_NUMBER")
+    tag = os.environ.get("GITHUB_REF_NAME") if os.environ.get("GITHUB_REF_TYPE") == "tag" else None
+
+    if tag:
+        return f"{tag}"
+    if pr and pr_num:
+        return f"pr-{pr_num}.{run or '0'}+{sha}"
+    if run and sha:
+        return f"build.{run}+{sha}"
+    # Local fallback: date stamp
+    return datetime.datetime.utcnow().strftime("local.%Y%m%d%H%M")


### PR DESCRIPTION
## Summary
- add `build_version()` helper for CI-based version strings
- expose computed version via `/health` and metadata exports
- update tests for new version handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897f73de354833091c43344c174e3f7