### PR TITLE
Expose version in generate response and display footer info

### DIFF
--- a/app.py
+++ b/app.py
@@ -78,7 +78,7 @@ def handle_exception(e):
 
 @app.get("/")
 def index():
-    return render_template("index.html", version=app.config["VERSION"])
+    return render_template("index.html")
 
 @app.get("/health")
 def health():
@@ -309,6 +309,7 @@ def generate():
             "ok": True,
             "jobId": job,
             "bpm": analysis.get("bpm"),
+            "version": APP_VERSION,
             "modelCount": len(models),
             "exportFormat": export_format,
             "downloadUrl": f"/download/{job}/{download_name}",

--- a/static/main.js
+++ b/static/main.js
@@ -25,7 +25,7 @@ function showResult(j) {
   out.className = 'result-panel';
   out.innerHTML = `
     <div><b>Export:</b> ${j.exportFormat}</div>
-    <div><b>BPM:</b> ${j.bpm ?? "auto/fallback"}</div>
+    <div><b>BPM:</b> ${j.bpm ?? "auto/fallback"} · v${j.version ?? "unknown"}</div>
     <div><b>Models:</b> ${j.modelCount}</div>
     <p><a href="${j.downloadUrl}" download>Download file</a></p>
   `;

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,7 +14,6 @@
     .download-btn { display:inline-block; margin-top:1rem; padding:1rem 2rem; font-size:1.1rem; background:#28a745; color:#fff; text-decoration:none; border-radius:8px; }
     .spinner { border:4px solid #f3f3f3; border-top:4px solid #444; border-radius:50%; width:24px; height:24px; animation:spin 1s linear infinite; display:none; margin-top:1rem; }
     @keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
-    .version { margin-top:2rem; color:#666; font-size:0.9rem; }
   </style>
 </head>
 <body>
@@ -62,9 +61,12 @@
     <div id="result"></div>
     <canvas id="previewCanvas" width="800" height="100" style="display:none; border:1px solid #ccc; margin-top:1rem;"></canvas>
 
-    <div class="version">Version: {{ version }}</div>
-    <footer>Offline mode: no telemetry.</footer>
-
     <script src="/static/main.js"></script>
+    <footer style="margin-top:2rem;color:#666"><small>Version: <span id="appver">loading…</span> · Offline mode: no telemetry</small></footer>
+    <script>
+    fetch('/health').then(r=>r.json()).then(j=>{
+      document.getElementById('appver').textContent = j.version || 'unknown';
+    });
+    </script>
   </body>
 </html>

--- a/tests/test_generate_version.py
+++ b/tests/test_generate_version.py
@@ -1,0 +1,45 @@
+import importlib
+import os, sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    import xlights_seq.config as config
+    importlib.reload(config)
+    config.Config.UPLOAD_FOLDER = str(tmp_path / "uploads")
+    config.Config.OUTPUT_FOLDER = str(tmp_path / "generated")
+    log_file = tmp_path / "app.log"
+    monkeypatch.setenv("LOG_FILE", str(log_file))
+    import app
+    importlib.reload(app)
+    with app.app.test_client() as client:
+        yield client, app
+
+
+def test_generate_includes_version(client, tmp_path, monkeypatch):
+    test_client, app_module = client
+    monkeypatch.setattr(
+        app_module,
+        "analyze_beats",
+        lambda path: {
+            "bpm": 120.0,
+            "duration_s": 1.0,
+            "beat_times": [0.0, 0.5],
+            "sections": [],
+        },
+    )
+    layout = "<layout><model name='Tree' StringCount='1'/></layout>"
+    layout_path = tmp_path / "layout.xml"
+    layout_path.write_text(layout)
+    audio_path = tmp_path / "audio.mp3"
+    audio_path.write_bytes(b"fake")
+    with layout_path.open("rb") as lf, audio_path.open("rb") as af:
+        data = {"layout": (lf, "layout.xml"), "audio": (af, "audio.mp3")}
+        resp = test_client.post(
+            "/generate", data=data, content_type="multipart/form-data"
+        )
+    assert resp.status_code == 200
+    j = resp.get_json()
+    assert j["version"] == app_module.APP_VERSION

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -37,7 +37,7 @@ def test_version_endpoint(client):
 def test_version_in_index(client):
     resp = client.get("/")
     assert resp.status_code == 200
-    assert f"Version: {EXPECTED_VERSION}".encode() in resp.data
+    assert b'id="appver"' in resp.data
 
 
 def test_health_includes_version(client):


### PR DESCRIPTION
## Summary
- Fetch app version via `/health` in a new footer and show offline mode
- Include `version` in `/generate` API response and display alongside BPM
- Update tests and add coverage for version in generation endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897fb2a87f48330a87f0dc18800d567