### PR TITLE
Add layout preview tree with search and toggles

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -56,6 +56,14 @@
     </form>
   </div>
 
+  <h2>Layout Preview</h2>
+  <div id="layoutTools">
+    <input id="searchBox" placeholder="Search models/groups…" />
+    <label><input type="checkbox" id="showGroups" checked> Show groups</label>
+    <label><input type="checkbox" id="showModels" checked> Show models</label>
+  </div>
+  <div id="modelTree" class="card"></div>
+
   <h2>Result</h2>
     <div id="spinner" class="spinner"></div>
     <div id="result"></div>


### PR DESCRIPTION
## Summary
- add layout preview section with search box and group/model toggles
- post layout file to /inspect-layout and render collapsible tree

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897ffe673a483308df8645fd5b1df4f