### PR TITLE
Support named timing tracks for beats, downbeats and sections

### DIFF
--- a/app.py
+++ b/app.py
@@ -262,8 +262,15 @@ def generate():
         {"time": float(t), "label": f"Section {i+1}"}
         for i, t in enumerate(section_times[1:], start=2)
     ]
-
-    tree = build_rgbeffects(models, beat_times, duration_ms, preset, sections, palette)
+    tree = build_rgbeffects(
+        models,
+        beat_times,
+        duration_ms,
+        preset,
+        downbeat_times,
+        section_times,
+        palette,
+    )
 
     job_dir = os.path.join(app.config["OUTPUT_FOLDER"], job)
     os.makedirs(job_dir, exist_ok=True)

--- a/tests/test_generator_mapping.py
+++ b/tests/test_generator_mapping.py
@@ -44,18 +44,19 @@ def test_small_model_uses_simple_effect_for_heavy_preset():
 def test_sections_timing_track():
     models = [ModelInfo(name="m1")]
     beat_times = [0, 1, 2, 3]
-    sections = [
-        {"time": 1.0, "label": "Intro"},
-        {"time": 2.0, "label": "Verse"},
-    ]
-    tree = build_rgbeffects(models, beat_times, duration_ms=4000, preset="solid_pulse", sections=sections)
+    section_times = [1.0, 2.0]
+    tree = build_rgbeffects(
+        models,
+        beat_times,
+        duration_ms=4000,
+        preset="solid_pulse",
+        section_times=section_times,
+    )
     root = tree.getroot()
     timing_tracks = root.findall("timing")
     names = [t.get("name") for t in timing_tracks]
     assert "Sections" in names
     sec_track = [t for t in timing_tracks if t.get("name") == "Sections"][0]
     markers = sec_track.findall("marker")
-    assert markers[0].get("label") == "Intro"
     assert markers[0].get("timeMS") == "1000"
-    assert markers[1].get("label") == "Verse"
     assert markers[1].get("timeMS") == "2000"

--- a/tests/test_generator_structure.py
+++ b/tests/test_generator_structure.py
@@ -11,7 +11,7 @@ def test_build_rgbeffects_structure():
     root = tree.getroot()
     assert root.tag == "xrgb"
 
-    timing = root.find("timing[@name='AutoBeat']")
+    timing = root.find("timing[@name='Beats']")
     markers = timing.findall("marker")
     assert [m.get("timeMS") for m in markers] == ["0", "500"]
 


### PR DESCRIPTION
## Summary
- add `add_timing_track` helper for creating timing tracks
- allow `build_rgbeffects` to accept downbeat and section times and emit named tracks
- wire app to supply new timing data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68980d34c9b4833098ed671e58ff4ad2