### PR TITLE
Expose generation metrics in sequence generator

### DIFF
--- a/app.py
+++ b/app.py
@@ -207,6 +207,11 @@ def generate():
     beat_times = analysis["beat_times"]
     downbeat_times = analysis.get("downbeat_times", [])
     section_times = analysis.get("section_times", [])
+    beat_count = len(beat_times)
+    downbeat_count = len(downbeat_times)
+    section_count = len(section_times)
+    selected_model_count = len(models)
+    total_model_count = selected_model_count
     sections = [
         {"time": float(t), "label": f"Section {i+1}"}
         for i, t in enumerate(section_times[1:], start=2)
@@ -289,8 +294,14 @@ def generate():
             "ok": True,
             "jobId": job,
             "bpm": analysis.get("bpm"),
+            "durationMs": duration_ms,
+            "beatCount": beat_count,
+            "downbeatCount": downbeat_count,
+            "sectionCount": section_count,
+            "modelCount": selected_model_count,
+            "selectedModelCount": selected_model_count,
+            "totalModelCount": total_model_count,
             "version": APP_VERSION,
-            "modelCount": len(models),
             "exportFormat": export_format,
             "downloadUrl": f"/download/{job}/{download_name}",
         }

--- a/static/main.js
+++ b/static/main.js
@@ -23,10 +23,15 @@ function showMessage(msg) {
 
 function showResult(j) {
   out.className = 'result-panel';
+  const durationSec = j.durationMs ? (j.durationMs / 1000).toFixed(2) : 'unknown';
+  const selCount = j.selectedModelCount ?? j.modelCount ?? 0;
+  const totalCount = j.totalModelCount ?? selCount;
   out.innerHTML = `
     <div><b>Export:</b> ${j.exportFormat}</div>
-    <div><b>BPM:</b> ${j.bpm ?? "auto/fallback"} · v${j.version ?? "unknown"}</div>
-    <div><b>Models:</b> ${j.modelCount}</div>
+    <div><b>BPM (auto):</b> ${j.bpm ?? "unknown"} · v${j.version ?? "unknown"}</div>
+    <div><b>Duration:</b> ${durationSec}s</div>
+    <div><b>Counts:</b> beats ${j.beatCount} · downbeats ${j.downbeatCount} · sections ${j.sectionCount}</div>
+    <div><b>Models:</b> ${selCount} / ${totalCount}</div>
     <p><a href="${j.downloadUrl}" download>Download file</a></p>
   `;
 }
@@ -67,6 +72,7 @@ form.addEventListener('submit', async (e) => {
       return;
     }
     showResult(j);
+    renderPreview(j.jobId, j.durationMs);
   } catch (err) {
     showError('Network error: ' + err.message);
   } finally {

--- a/tests/test_generate_metrics.py
+++ b/tests/test_generate_metrics.py
@@ -1,0 +1,53 @@
+import importlib
+import os, sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    import xlights_seq.config as config
+    importlib.reload(config)
+    config.Config.UPLOAD_FOLDER = str(tmp_path / "uploads")
+    config.Config.OUTPUT_FOLDER = str(tmp_path / "generated")
+    log_file = tmp_path / "app.log"
+    monkeypatch.setenv("LOG_FILE", str(log_file))
+    import app
+    importlib.reload(app)
+    with app.app.test_client() as client:
+        yield client, app
+
+
+def test_generate_returns_counts(client, tmp_path, monkeypatch):
+    test_client, app_module = client
+    monkeypatch.setattr(
+        app_module,
+        "analyze_beats_plus",
+        lambda path: {
+            "bpm": 120.0,
+            "duration_s": 2.0,
+            "beat_times": [0.0, 0.5, 1.0, 1.5],
+            "downbeat_times": [0.0, 1.0],
+            "section_times": [0.0, 1.0],
+        },
+    )
+    layout = "<layout><model name='Tree' StringCount='1'/></layout>"
+    layout_path = tmp_path / "layout.xml"
+    layout_path.write_text(layout)
+    audio_path = tmp_path / "audio.mp3"
+    audio_path.write_bytes(b"fake")
+    with layout_path.open("rb") as lf, audio_path.open("rb") as af:
+        data = {"layout": (lf, "layout.xml"), "audio": (af, "audio.mp3")}
+        resp = test_client.post(
+            "/generate", data=data, content_type="multipart/form-data"
+        )
+    assert resp.status_code == 200
+    j = resp.get_json()
+    assert j["durationMs"] == 2000
+    assert j["beatCount"] == 4
+    assert j["downbeatCount"] == 2
+    assert j["sectionCount"] == 2
+    assert j["selectedModelCount"] == 1
+    assert j["totalModelCount"] == 1
+


### PR DESCRIPTION
## Summary
- return BPM, duration, beat/downbeat/section counts and model counts from `/generate`
- show new metrics in frontend after sequence generation
- test `/generate` metrics

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68981622e8648330b90f4690f47ab3b6