### PR TITLE
Add group recommendation UI and handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -153,6 +153,12 @@ def generate():
         if not palette:
             palette = None
 
+    selected_recs = request.form.get("selected_recommendations")
+    try:
+        selected_recs = json.loads(selected_recs) if selected_recs else []
+    except Exception:
+        selected_recs = []
+
     if not layout or not audio:
         return (
             jsonify({"ok": False, "error": "Both layout XML and audio are required."}),

--- a/templates/index.html
+++ b/templates/index.html
@@ -64,6 +64,12 @@
   </div>
   <div id="modelTree" class="card"></div>
 
+  <h2>Recommendations</h2>
+  <div id="recs" class="card">
+    <button type="button" id="btnRecs">Analyze Layout & Recommend Groups</button>
+    <div id="recsList"></div>
+  </div>
+
   <h2>Result</h2>
     <div id="spinner" class="spinner"></div>
     <div id="result"></div>


### PR DESCRIPTION
## Summary
- Show new Recommendations card to analyze layout and choose suggested groups
- Wire client to request recommendations and include selected ones when generating
- Parse selected recommendations on backend for future use

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689824f025588330b3285f519e07b8f0