### PR TITLE
Allow boosting selected groups in RGB effect generator

### DIFF
--- a/tests/test_generator_mapping.py
+++ b/tests/test_generator_mapping.py
@@ -60,3 +60,21 @@ def test_sections_timing_track():
     markers = sec_track.findall("marker")
     assert markers[0].get("timeMS") == "1000"
     assert markers[1].get("timeMS") == "2000"
+
+
+def test_preferred_groups_boosts_effect():
+    m1 = ModelInfo(name="plain1")
+    m2 = ModelInfo(name="plain2")
+    beat_times = [0, 1]
+    tree = build_rgbeffects(
+        [m1, m2],
+        beat_times,
+        duration_ms=2000,
+        preset="solid_pulse",
+        preferred_groups=["plain1"],
+    )
+    root = tree.getroot()
+    e1 = root.find("./model[@name='plain1']//effect")
+    e2 = root.find("./model[@name='plain2']//effect")
+    assert e1.get("type") == "Bars"
+    assert e2.get("type") == "On"


### PR DESCRIPTION
## Summary
- allow `build_rgbeffects` to take an optional `preferred_groups` list
- boost matching models to use brighter presets and stronger effects
- add tests covering preferred group boosting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689826699110833087d972ca7dbcc9e9