### PR TITLE
Add starter sequence intel resources

### DIFF
--- a/intel/House_Style_CheatSheet.txt
+++ b/intel/House_Style_CheatSheet.txt
@@ -1,0 +1,6 @@
+House Style Cheat Sheet
+-----------------------
+- Use CamelCase for model names.
+- Group names should be descriptive (e.g., RoofOutline, MegaTree).
+- Timing marks follow 10ms resolution.
+- Layout file xlights_rgbeffects.xml is read-only; do not overwrite.

--- a/intel/Starter_Sequence_Plan.yaml
+++ b/intel/Starter_Sequence_Plan.yaml
@@ -1,0 +1,14 @@
+# Plan for the starter xLights sequence.
+# Model and group names should match those defined in xlights_rgbeffects.xml.
+sequence_name: Starter Sequence
+music: TBD
+models:
+  - ExampleModel
+  - ExampleGroup
+steps:
+  - time: 0
+    action: fade_in
+    targets: [ExampleModel]
+  - time: 5
+    action: sparkle
+    targets: [ExampleGroup]


### PR DESCRIPTION
## Summary
- add starter sequence plan yaml and house style cheat sheet under new intel folder

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898e16155608330be75d9e5806f8c05