### PR TITLE
Add plan module with plan/style loaders

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ librosa==0.10.2.post1
 soundfile==0.12.1
 numpy==1.26.4
 pytest==8.2.0
+pyyaml==6.0.1

--- a/xlights_seq/plan.py
+++ b/xlights_seq/plan.py
@@ -1,0 +1,29 @@
+import os, re, yaml, json
+from dataclasses import dataclass
+
+@dataclass
+class HouseStyle:
+    core_groups: dict
+    effects_kit: dict
+    section_recipes: dict
+
+
+def load_plan(path="intel/Starter_Sequence_Plan.yaml") -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def load_style(path="intel/House_Style_CheatSheet.txt") -> HouseStyle:
+    txt = open(path, "r", encoding="utf-8").read()
+    # extremely light parsing: bullet lists → buckets
+    def bucket(name):
+        m = re.search(rf"{name}:\s*(.+?)(?:\n\n|\Z)", txt, re.S|re.I)
+        return (m.group(1).strip() if m else "")
+    core = bucket("Core Groups to Target")
+    kit  = bucket("Effects Default Kit")
+    recs = bucket("Section Recipes")
+    return HouseStyle(
+        core_groups={"raw": core},
+        effects_kit={"raw": kit},
+        section_recipes={"raw": recs}
+    )


### PR DESCRIPTION
## Summary
- add module for loading starter plans and parsing house style cheat sheets
- declare pyyaml dependency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898ecf350548330bf950dfb3ec5da61