### PR TITLE
Add plotly dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ soundfile==0.12.1
 numpy==1.26.4
 pytest==8.2.0
 pyyaml==6.0.1
+plotly==5.22.0


### PR DESCRIPTION
## Summary
- add plotly 5.22.0 requirement

## Testing
- `pytest`
- `docker build -t xlights-sequence-generator:latest .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_689aa9c6856c833085a8aaf1aead660c