### PR TITLE
Add intent-driven XSQ writer and layout group mapping

### DIFF
--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -52,10 +52,13 @@ def test_layout_groups_and_fuzzy_match(tmp_path):
     ET.SubElement(xml, "group", name="Garage")
     ET.ElementTree(xml).write(tmp_path / "layout.xml")
 
-    layout_groups, models_index = parse_layout_groups_and_models(str(tmp_path / "layout.xml"))
+    layout_groups, models_index, models_by_group = parse_layout_groups_and_models(
+        str(tmp_path / "layout.xml")
+    )
     assert set(layout_groups) == {"Focal Tree", "Garage"}
     assert models_index["Tree"].strings == 5
     assert models_index["Star"].nodes == 50
+    assert models_by_group == {"Focal Tree": [], "Garage": []}
 
     mapping = map_style_groups_to_layout(["Focal_Tree", "Garage/Porch", "Other"], layout_groups)
     assert mapping == {"Focal_Tree": "Focal Tree", "Garage/Porch": "Garage"}

--- a/tests/test_xsq_writer_intents.py
+++ b/tests/test_xsq_writer_intents.py
@@ -1,0 +1,26 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from xlights_seq.xsq_writer import build_xsq_from_intents
+from xlights_seq.intel_engine import Intent
+
+
+def test_build_xsq_from_intents_basic():
+    models_by_group = {"GroupA": ["Model1", "Model2"]}
+    timing = {"beats": [0.0, 1.0], "downbeats": [], "bars": [], "sections": []}
+    intents = [
+        Intent("SG", "GroupA", "On", 0.0, 0.5, {"color": "#FFFFFF"})
+    ]
+    tree = build_xsq_from_intents(models_by_group, timing, intents, 2.0)
+    root = tree.getroot()
+
+    models = {m.get("name"): m for m in root.findall("model")}
+    assert set(models) == {"Model1", "Model2"}
+    for m in models.values():
+        eff = m.find("./effectLayer/effect")
+        assert eff is not None
+        assert eff.get("type") == "On"
+        assert eff.get("startMS") == "0"
+        assert eff.get("endMS") == "500"
+    beats_track = root.find("timing[@name='Beats']")
+    assert beats_track is not None
+    assert beats_track.find("marker").get("timeMS") == "0"


### PR DESCRIPTION
## Summary
- extend XSQ writer with helpers for timing tracks, effect creation, and `build_xsq_from_intents`
- expose layout `models_by_group` mapping alongside group names and model index
- add tests for new writer and parser behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ab02e9b288330a8c38f48206f7eb1